### PR TITLE
Fix translate language setting not persisting across reloads

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -8242,6 +8242,8 @@ ${distance ? `<div class="geohash-info-item"><strong>Distance:</strong> ${distan
                     // Sync the settings modal select if it exists
                     const select = document.getElementById('translateLanguageSelect');
                     if (select) select.value = code;
+                    // Persist to relay so it survives reload
+                    if (typeof nostrSettingsSave === 'function') nostrSettingsSave();
                     cleanup(code);
                 });
                 btn.addEventListener('mouseenter', () => {
@@ -9741,6 +9743,7 @@ ${distance ? `<div class="geohash-info-item"><strong>Distance:</strong> ${distan
                 textSize: this.settings.textSize || parseInt(localStorage.getItem('nym_text_size') || '15', 10),
                 lowDataMode: this.settings.lowDataMode || localStorage.getItem('nym_low_data_mode') === 'true',
                 groupChatPMOnlyMode: this.settings.groupChatPMOnlyMode || false,
+                translateLanguage: this.settings.translateLanguage || '',
                 notificationsEnabled: this.notificationsEnabled !== false,
                 notificationLastReadTime: this.notificationLastReadTime || 0,
                 closedPMs: Array.from(this.closedPMs || [])
@@ -25288,6 +25291,7 @@ function clearLocalStorageCache() {
             key === 'nym_session_nsec' ||
             key === 'nym_random_keypair_per_session' ||
             key === 'nym_dev_nsec' ||
+            key === 'nym_translate_language' ||
             key === 'nym_active_style' ||
             key === 'nym_active_flair' ||
             key === 'nym_shop_active_cache' ||


### PR DESCRIPTION
## Summary
- **Sync language choice to relay**: `_promptTranslateLanguage()` now calls `nostrSettingsSave()` after saving to localStorage, so the relay has the correct value when the app reloads
- **Include in ephemeral sync**: Added `translateLanguage` to `saveSyncedSettings()` payload so ephemeral users also get their language setting synced to relays
- **Preserve on cache clear**: Added `nym_translate_language` to the preserved keys list in `clearLocalStorageCache()` so the setting survives cache resets

## Root cause
When a user picked a language via the translate prompt modal, it was saved to `localStorage` and in-memory state but never synced to the Nostr relay. On reload, the relay settings (with empty `translateLanguage`) overwrote the local value, causing the prompt to reappear.

## Test plan
- [ ] Select a translate language via the prompt modal, reload the app, and translate a message — it should use the previously chosen language without re-prompting
- [ ] Verify the same behavior for ephemeral (non-Nostr-login) users
- [ ] Clear local storage cache and confirm the translate language setting is preserved

https://claude.ai/code/session_01AE13fxtAb3vJe97oeqcr5D