### PR TITLE
Add download button to image/video modal

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2650,9 +2650,30 @@ body.chat-bubbles .edited-indicator-irc {
     transition: all var(--transition);
 }
 
-.image-modal-close:hover {
+.image-modal-close:hover,
+.image-modal-download:hover {
     background: rgba(255, 255, 255, 0.1);
     border-color: rgba(255, 255, 255, 0.2);
+}
+
+.image-modal-download {
+    position: absolute;
+    top: 20px;
+    right: 70px;
+    color: var(--text);
+    font-size: 22px;
+    cursor: pointer;
+    background: rgba(20, 20, 35, 0.8);
+    backdrop-filter: blur(20px);
+    border: 1px solid var(--glass-border);
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all var(--transition);
+    z-index: 10002;
 }
 
 .mobile-menu-toggle,
@@ -4865,7 +4886,8 @@ body.light-mode .message-time:hover::after {
     color: var(--text);
 }
 
-body.light-mode .image-modal-close {
+body.light-mode .image-modal-close,
+body.light-mode .image-modal-download {
     backdrop-filter: blur(20px);
     border-color: rgba(0, 0, 0, 0.08);
 }

--- a/index.html
+++ b/index.html
@@ -637,6 +637,7 @@
     <!-- Image/Video Modal -->
     <div class="image-modal" id="imageModal" onclick="closeImageModal()">
         <span class="image-modal-close" onclick="closeImageModal()">×</span>
+        <span class="image-modal-download" onclick="downloadModalMedia(event)" title="Download">⤓</span>
         <img id="modalImage" src="" alt="Expanded image">
         <video id="modalVideo" controls playsinline webkit-playsinline style="display:none; max-width:90%; max-height:90%; border:1px solid var(--glass-border); border-radius: var(--radius-md); box-shadow: var(--shadow-lg);"></video>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -24157,6 +24157,45 @@ function closeImageModal() {
     modalVid.load();
 }
 
+function downloadModalMedia(event) {
+    event.stopPropagation();
+    const modalImg = document.getElementById('modalImage');
+    const modalVid = document.getElementById('modalVideo');
+    let src = '';
+    let defaultName = 'download';
+
+    if (modalImg.style.display !== 'none' && modalImg.src) {
+        src = modalImg.src;
+        const ext = src.split('.').pop().split('?')[0].toLowerCase();
+        const imageExts = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+        defaultName = 'image.' + (imageExts.includes(ext) ? ext : 'jpg');
+    } else if (modalVid.style.display !== 'none') {
+        src = modalVid.src || (modalVid.querySelector('source') && modalVid.querySelector('source').src) || '';
+        const ext = src.split('.').pop().split('?')[0].toLowerCase();
+        const videoExts = ['mp4', 'webm', 'ogg', 'mov'];
+        defaultName = 'video.' + (videoExts.includes(ext) ? ext : 'mp4');
+    }
+
+    if (!src) return;
+
+    fetch(src)
+        .then(resp => resp.blob())
+        .then(blob => {
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = defaultName;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        })
+        .catch(() => {
+            // Fallback: open in new tab
+            window.open(src, '_blank');
+        });
+}
+
 function addPollOption() {
     const container = document.getElementById('pollOptionsContainer');
     const existing = container.querySelectorAll('[data-poll-option]');


### PR DESCRIPTION
## Summary
- Adds a download button (⤓) next to the close (×) button in the image/video modal
- Clicking it downloads the currently displayed image or video with the correct file extension
- Uses fetch + blob approach for a proper download, with fallback to opening in a new tab
- Styled consistently with the existing close button, including light mode support

## Test plan
- [ ] Open a message containing an image, click to expand in modal, verify the download button appears next to the close button
- [ ] Click the download button on an expanded image — confirm the file downloads with the correct extension (e.g. `.jpg`, `.png`, `.gif`)
- [ ] Open a message containing a video, expand in modal, click the download button — confirm the video file downloads
- [ ] Verify clicking the download button does NOT close the modal (event propagation is stopped)
- [ ] Test in light mode to ensure the button styling matches the close button
- [ ] Test on mobile to ensure the button is accessible and properly positioned

https://claude.ai/code/session_01HwBBuKfcFQfXf2h85sR8Vq