### PR TITLE
Remove client identifier tags from Nostr events

### DIFF
--- a/functions/api/bot.js
+++ b/functions/api/bot.js
@@ -2667,7 +2667,6 @@ async function onRequest(context) {
     created_at: now,
     tags: [
       ["n", BOT_NYM],
-      ["client", "nymchat"],
       ["bot", "nymchat"],
       ["g", geohash || "nym"]
     ],

--- a/js/app.js
+++ b/js/app.js
@@ -15475,8 +15475,7 @@ ${Object.entries(this.allEmojis).map(([category, emojis]) => `
 
             const now = Math.floor(Date.now() / 1000);
             const tags = [
-                ['n', this.nym],
-                ['client', 'nymchat']
+                ['n', this.nym]
             ];
 
             const kind = 20000; // Geohash channels use kind 20000
@@ -15578,8 +15577,7 @@ ${Object.entries(this.allEmojis).map(([category, emojis]) => `
 
             const now = Math.floor(Date.now() / 1000);
             const tags = [
-                ['n', anonNym],
-                ['client', 'nymchat']
+                ['n', anonNym]
             ];
 
             const kind = 20000;
@@ -15887,8 +15885,7 @@ ${Object.entries(this.allEmojis).map(([category, emojis]) => `
         // Determine channel info and kind for the offer event
         let tags = [
             ['n', this.nym],
-            ['offer', JSON.stringify(fileOffer)],
-            ['client', 'nymchat']
+            ['offer', JSON.stringify(fileOffer)]
         ];
 
         let kind;
@@ -16640,8 +16637,7 @@ ${Object.entries(this.allEmojis).map(([category, emojis]) => `
         const tags = [
             ['n', this.nym],
             ['offer', JSON.stringify(fileOffer)],
-            ['g', this.currentGeohash],
-            ['client', 'nymchat']
+            ['g', this.currentGeohash]
         ];
 
         // Create and broadcast the file offer event
@@ -19386,8 +19382,7 @@ ${Object.entries(this.allEmojis).map(([category, emojis]) => `
             const tags = [
                 ['n', this.nym],
                 ['g', geohash],
-                ['edit', originalEventId], // Tag referencing the original message being edited
-                ['client', 'nymchat']
+                ['edit', originalEventId]
             ];
 
             let event = {


### PR DESCRIPTION
## Summary

- Removes all `['client', 'nymchat']` tags from outgoing Nostr events across `js/app.js` (5 instances) and `functions/api/bot.js` (1 instance)
- This tag was never used for filtering or any application logic — it only served as a fingerprint identifying the sending client
- Removing it improves user anonymity by eliminating metadata that could be used to identify which app a user is broadcasting from

## Test plan

- [ ] Send a regular message and verify it broadcasts successfully without the client tag
- [ ] Send an anonymous message and verify it works without the client tag
- [ ] Share a file (P2P offer) and verify the offer event is created correctly
- [ ] Share a torrent file and verify the offer event is created correctly
- [ ] Edit a message and verify the edit event works without the client tag
- [ ] Verify the bot still responds correctly without the client tag

https://claude.ai/code/session_01P1bZZgMSLM11Fq77jTaBNK