### PR TITLE
Allow users to remove their own message reactions

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10559,16 +10559,27 @@ ${distance ? `<div class="geohash-info-item"><strong>Distance:</strong> ${distan
             // For reactions (kind 7)
             if (event.kind === 7) {
                 const eTag = event.tags.find(t => t[0] === 'e');
+                const actionTag = event.tags.find(t => t[0] === 'action');
+                const isRemoval = actionTag && actionTag[1] === 'remove';
                 if (eTag) {
                     const messageId = eTag[1];
                     const emoji = event.content;
 
-                    // Check if we already have this reaction in state
-                    if (this.reactions.has(messageId)) {
+                    if (isRemoval) {
+                        // Check if we already removed this reaction optimistically
                         const messageReactions = this.reactions.get(messageId);
-                        if (messageReactions.has(emoji) &&
-                            messageReactions.get(emoji).has(this.pubkey)) {
-                            return; // Already added optimistically, skip
+                        if (!messageReactions || !messageReactions.has(emoji) ||
+                            !messageReactions.get(emoji).has(this.pubkey)) {
+                            return; // Already removed optimistically, skip
+                        }
+                    } else {
+                        // Check if we already have this reaction in state
+                        if (this.reactions.has(messageId)) {
+                            const messageReactions = this.reactions.get(messageId);
+                            if (messageReactions.has(emoji) &&
+                                messageReactions.get(emoji).has(this.pubkey)) {
+                                return; // Already added optimistically, skip
+                            }
                         }
                     }
                 }
@@ -11453,6 +11464,8 @@ ${distance ? `<div class="geohash-info-item"><strong>Distance:</strong> ${distan
         const eTag = event.tags.find(t => t[0] === 'e');
         const kTag = event.tags.find(t => t[0] === 'k');
         const pTag = event.tags.find(t => t[0] === 'p');
+        const actionTag = event.tags.find(t => t[0] === 'action');
+        const isRemoval = actionTag && actionTag[1] === 'remove';
 
         if (!eTag) return;
 
@@ -11483,6 +11496,36 @@ ${distance ? `<div class="geohash-info-item"><strong>Distance:</strong> ${distan
         }
 
         const reactorNym = this.getNymFromPubkey(event.pubkey);
+
+        // Handle reaction removal
+        if (isRemoval) {
+            const messageReactions = this.reactions.get(messageId);
+            if (messageReactions && messageReactions.has(reactionContent)) {
+                messageReactions.get(reactionContent).delete(event.pubkey);
+                if (messageReactions.get(reactionContent).size === 0) {
+                    messageReactions.delete(reactionContent);
+                }
+                if (messageReactions.size === 0) {
+                    this.reactions.delete(messageId);
+                }
+            }
+            const reactionApplied = this.updateMessageReactions(messageId);
+            if (!reactionApplied) {
+                for (const [key, msgs] of this.messages.entries()) {
+                    if (msgs.some(m => m.id === messageId)) {
+                        this.channelDOMCache.delete(key);
+                        break;
+                    }
+                }
+                for (const [key, msgs] of this.pmMessages.entries()) {
+                    if (msgs.some(m => m.id === messageId || m.nymMessageId === messageId)) {
+                        this.channelDOMCache.delete(key);
+                        break;
+                    }
+                }
+            }
+            return;
+        }
 
         // Store reaction with pubkey and nym
         if (!this.reactions.has(messageId)) {
@@ -11720,7 +11763,7 @@ ${distance ? `<div class="geohash-info-item"><strong>Distance:</strong> ${distan
                 if (!hasReacted) {
                     await this.sendReaction(messageId, emoji);
                 } else {
-                    this.displaySystemMessage(`You already reacted with ${emoji}`);
+                    await this.removeReaction(messageId, emoji);
                 }
             };
 
@@ -12192,6 +12235,102 @@ ${Object.entries(this.allEmojis).map(([category, emojis]) => `
                 messageReactions.get(emoji).delete(this.pubkey);
                 this.updateMessageReactions(messageId);
             }
+        }
+    }
+
+    async removeReaction(messageId, emoji) {
+        try {
+            const messageEl = document.querySelector(`[data-message-id="${messageId}"]`);
+            if (!messageEl) return;
+
+            const targetPubkey = messageEl.dataset.pubkey;
+            if (!targetPubkey) return;
+
+            // Remove reaction from local state immediately
+            const messageReactions = this.reactions.get(messageId);
+            if (!messageReactions || !messageReactions.has(emoji)) return;
+            messageReactions.get(emoji).delete(this.pubkey);
+            if (messageReactions.get(emoji).size === 0) {
+                messageReactions.delete(emoji);
+            }
+            if (messageReactions.size === 0) {
+                this.reactions.delete(messageId);
+            }
+
+            // Update UI immediately
+            this.updateMessageReactions(messageId);
+
+            // Infer original kind from message context
+            let originalKind = '20000';
+            if (messageEl.classList.contains('pm') || messageEl.dataset.isPM === '1') {
+                originalKind = '1059';
+            }
+
+            const event = {
+                kind: 7,
+                created_at: Math.floor(Date.now() / 1000),
+                tags: [
+                    ['e', messageId],
+                    ['p', targetPubkey],
+                    ['k', originalKind],
+                    ['action', 'remove']
+                ],
+                content: emoji,
+                pubkey: this.pubkey
+            };
+
+            // For group messages: send unreact as gift wrap to all members
+            const groupId = messageEl.dataset.groupId;
+            if (groupId && this._canSendGiftWraps()) {
+                const group = this.groupConversations.get(groupId);
+                if (group) {
+                    const now = Math.floor(Date.now() / 1000);
+                    const reactionRumor = {
+                        kind: 7,
+                        created_at: now,
+                        tags: [['g', groupId], ['e', messageId], ['k', '14'], ['action', 'remove']],
+                        content: emoji,
+                        pubkey: this.pubkey
+                    };
+                    await this._sendGiftWrapsAsync(group.members, reactionRumor, null);
+                    return;
+                }
+            }
+
+            // For 1:1 PM messages: send unreact as gift wrap to the peer
+            if (messageEl.dataset.isPM === '1' && !groupId && this._canSendGiftWraps() && this.currentPM) {
+                const now = Math.floor(Date.now() / 1000);
+                const reactionRumor = {
+                    kind: 7,
+                    created_at: now,
+                    tags: [['e', messageId], ['p', targetPubkey], ['k', '1059'], ['action', 'remove']],
+                    content: emoji,
+                    pubkey: this.pubkey
+                };
+                await this._sendGiftWrapsAsync([this.pubkey, this.currentPM], reactionRumor, null);
+                return;
+            }
+
+            const signedEvent = await this.signEvent(event);
+
+            if (signedEvent) {
+                this.sendToRelay(["EVENT", signedEvent]);
+            } else {
+                // Signing failed - revert the optimistic removal
+                if (!this.reactions.has(messageId)) this.reactions.set(messageId, new Map());
+                const mr = this.reactions.get(messageId);
+                if (!mr.has(emoji)) mr.set(emoji, new Map());
+                mr.get(emoji).set(this.pubkey, this.nym);
+                this.updateMessageReactions(messageId);
+                this.displaySystemMessage('Failed to sign reaction removal');
+            }
+        } catch (error) {
+            // Revert optimistic removal on error
+            if (!this.reactions.has(messageId)) this.reactions.set(messageId, new Map());
+            const mr = this.reactions.get(messageId);
+            if (!mr.has(emoji)) mr.set(emoji, new Map());
+            mr.get(emoji).set(this.pubkey, this.nym);
+            this.updateMessageReactions(messageId);
         }
     }
 
@@ -13492,7 +13631,18 @@ ${Object.entries(this.allEmojis).map(([category, emojis]) => `
                 if (eTag) {
                     const reactionMessageId = eTag[1];
                     const emoji = rumor.content;
-                    if (emoji) {
+                    const actionTag = (rumor.tags || []).find(t => Array.isArray(t) && t[0] === 'action');
+                    const isRemoval = actionTag && actionTag[1] === 'remove';
+
+                    if (emoji && isRemoval) {
+                        const msgReactions = this.reactions.get(reactionMessageId);
+                        if (msgReactions && msgReactions.has(emoji)) {
+                            msgReactions.get(emoji).delete(senderPubkey);
+                            if (msgReactions.get(emoji).size === 0) msgReactions.delete(emoji);
+                            if (msgReactions.size === 0) this.reactions.delete(reactionMessageId);
+                        }
+                        this.updateMessageReactions(reactionMessageId);
+                    } else if (emoji) {
                         const reactorNym = this.getNymFromPubkey(senderPubkey);
                         if (!this.reactions.has(reactionMessageId)) this.reactions.set(reactionMessageId, new Map());
                         const msgReactions = this.reactions.get(reactionMessageId);
@@ -13833,6 +13983,20 @@ ${Object.entries(this.allEmojis).map(([category, emojis]) => `
         const messageId = eTag[1]; // nymMessageId of the target message
         const emoji = rumor.content;
         if (!emoji) return;
+
+        const actionTag = (rumor.tags || []).find(t => Array.isArray(t) && t[0] === 'action');
+        const isRemoval = actionTag && actionTag[1] === 'remove';
+
+        if (isRemoval) {
+            const messageReactions = this.reactions.get(messageId);
+            if (messageReactions && messageReactions.has(emoji)) {
+                messageReactions.get(emoji).delete(senderPubkey);
+                if (messageReactions.get(emoji).size === 0) messageReactions.delete(emoji);
+                if (messageReactions.size === 0) this.reactions.delete(messageId);
+            }
+            this.updateMessageReactions(messageId);
+            return;
+        }
 
         const reactorNym = this.getNymFromPubkey(senderPubkey);
         if (!this.reactions.has(messageId)) this.reactions.set(messageId, new Map());


### PR DESCRIPTION
## Summary
- Clicking a reaction badge you've already reacted with now **removes** your reaction instead of showing "You already reacted"
- Unreact events are published as kind 7 with an `['action', 'remove']` tag, following the same transport paths as reactions (relay for channel messages, gift wrap for group and 1:1 PMs)
- All three reaction handlers (channel, group PM, 1:1 PM) detect and process removal events, cleaning up local state and updating the UI
- Optimistic UI updates with rollback on failure, matching the existing `sendReaction()` pattern

## Test plan
- [ ] React to a message, then click the reaction badge again — reaction should be removed
- [ ] Verify other users see the reaction disappear in real-time
- [ ] Reload the app and confirm the removed reaction does not reappear
- [ ] Test unreacting in group PMs and 1:1 PMs
- [ ] Test that long-press still shows the reactors modal (not affected)
- [ ] Test that adding new reactions still works as before

https://claude.ai/code/session_012pvabozAtozwACZfqD3DUi